### PR TITLE
APFM-365: Update to Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,5 +9,5 @@ inputs:
     required: true
     description: 'Token used to create a check using Github API'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
> For Actions maintainers: Update your actions to run on Node 16 instead of Node 12 ([Actions configuration settings](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-javascript-actions))
https://github.blog/changelog/2023-05-04-github-actions-all-actions-will-run-on-node16-instead-of-node12/

https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-javascript-actions

And we can maybe merge the dependabot one:
https://github.com/scoremedia/action-coverage-check/pull/321